### PR TITLE
Reset the simulation when restarting autonomous

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -44,6 +44,9 @@ public final class Constants {
 
 
   public static final class Drive {
+    // Measured by driving straight forwards approximately 15.8 m in 4.1 seconds and
+    // rounding up due to the acceleration.
+    public static final double MAX_SPEED_MPS = 4.;
     public static final double TRACK_WIDTH_METERS = 0.56;
 
     public final static double WHEEL_CIRCUM = 46.8;

--- a/src/main/java/frc/robot/sim/DrivebaseSim.java
+++ b/src/main/java/frc/robot/sim/DrivebaseSim.java
@@ -7,7 +7,11 @@ import com.revrobotics.CANSparkMax;
 import edu.wpi.first.hal.HALValue;
 import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.hal.simulation.SimDeviceDataJNI;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.simulation.DifferentialDrivetrainSim;
 import frc.robot.Constants.Drive;
@@ -33,7 +37,7 @@ public class DrivebaseSim {
   public static final String ALT_ENCODER_POSITION = "Alt Encoder Position";
   public static final String STALL_TORQUE = "Stall Torque";
   public static final String FREE_SPEED = "Free Speed";
-  
+
   // Simulation value handles that are ints
   public static final String FAULTS = "Faults";
   public static final String STICKY_FAULTS = "Sticky Faults";
@@ -56,7 +60,8 @@ public class DrivebaseSim {
   private SimDouble m_leftVelocityMetersPerSecond;
   private SimDouble m_rightVelocityMetersPerSecond;
 
-  // Suggested code from https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/java/
+  // Suggested code from
+  // https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/java/
   public static final String GYRO_DEVICE_NAME = "navX-Sensor[0]";
   private SimDouble m_yaw;
 
@@ -64,42 +69,61 @@ public class DrivebaseSim {
 
   public DrivebaseSim(CANSparkMax leftMotor, CANSparkMax rightMotor) {
     m_drivetrainSim = new DifferentialDrivetrainSim(
-      DCMotor.getNEO(2),
-      Drive.WHEEL_GEAR_RATIO,
-      // FIXME: These values are defaults from
-      // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.html
-      // and really should be measured.
-      7.5,
-      60.0,
-      // This value is the wheel radius in metres
-      Drive.WHEEL_CIRCUM / 100. / Math.PI / 2.,
-      Drive.TRACK_WIDTH_METERS,
-      // TODO: Add noise to the simulation here as standard deviation values for noise:
-      // x, y in m
-      // heading in rad
-      // l/r velocity m/s
-      // l/r position in m
-      VecBuilder.fill(0, 0, 0, 0, 0, 0, 0)
-    );
+        DCMotor.getNEO(2),
+        Drive.WHEEL_GEAR_RATIO,
+        // FIXME: These values are defaults from
+        // https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-simulation/drivesim-tutorial/drivetrain-model.html
+        // and really should be measured.
+        7.5,
+        112.0,
+        // This value is the wheel radius in metres
+        Drive.WHEEL_CIRCUM / 100. / Math.PI / 2.,
+        Drive.TRACK_WIDTH_METERS,
+        // TODO: Add noise to the simulation here as standard deviation values for
+        // noise:
+        // x, y in m
+        // heading in rad
+        // l/r velocity m/s
+        // l/r position in m
+        VecBuilder.fill(0, 0, 0, 0, 0, 0, 0));
 
     m_leftMotor = leftMotor;
     m_rightMotor = rightMotor;
     m_leftMotorDeviceHandle = SimDeviceDataJNI.getSimDeviceHandle("SPARK MAX [" + leftMotor.getDeviceId() + "]");
     m_rightMotorDeviceHandle = SimDeviceDataJNI.getSimDeviceHandle("SPARK MAX [" + rightMotor.getDeviceId() + "]");
-    m_leftAppliedOutput = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, DrivebaseSim.APPLIED_OUTPUT));
-    m_rightAppliedOutput = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, DrivebaseSim.APPLIED_OUTPUT));
+    m_leftAppliedOutput = new SimDouble(
+        SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, DrivebaseSim.APPLIED_OUTPUT));
+    m_rightAppliedOutput = new SimDouble(
+        SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, DrivebaseSim.APPLIED_OUTPUT));
     m_leftPositionMeters = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, POSITION));
     m_rightPositionMeters = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, POSITION));
-    m_leftVelocityMetersPerSecond = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, VELOCITY));
-    m_rightVelocityMetersPerSecond = new SimDouble(SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, VELOCITY));
+    m_leftVelocityMetersPerSecond = new SimDouble(
+        SimDeviceDataJNI.getSimValueHandle(m_leftMotorDeviceHandle, VELOCITY));
+    m_rightVelocityMetersPerSecond = new SimDouble(
+        SimDeviceDataJNI.getSimValueHandle(m_rightMotorDeviceHandle, VELOCITY));
 
     int gyroDeviceHandle = SimDeviceDataJNI.getSimDeviceHandle(GYRO_DEVICE_NAME);
     m_yaw = new SimDouble(SimDeviceDataJNI.getSimValueHandle(gyroDeviceHandle, "Yaw"));
   }
 
+  public void disable() {
+    // m_drivetrainSim.setState(new Matrix<>(Nat.N7(), Nat.N1()));
+    // m_leftVelocityMetersPerSecond.set(0);
+    // m_rightVelocityMetersPerSecond.set(0);
+  }
+
+  public void reset(Pose2d pose) {
+    // Reset the drivetrain simulator to be at the new position, but keep the
+    // original facing.
+    // Since we do not reset the gyro in the drivebase subsystem, we have to keep
+    // the same heading
+    // here even after reset.
+    Pose2d originalFacingPose = new Pose2d(pose.getTranslation(),
+        new Rotation2d(m_drivetrainSim.getHeading().getRadians()));
+    m_drivetrainSim.setPose(originalFacingPose);
+  }
+
   private void updateAppliedOutput() {
-    //m_leftAppliedOutput.set(1 * m_leftMotor.getBusVoltage());
-    //m_rightAppliedOutput.set(1 * m_rightMotor.getBusVoltage());
     m_leftAppliedOutput.set(m_leftMotor.get() * m_leftMotor.getBusVoltage());
     m_rightAppliedOutput.set(m_rightMotor.get() * m_rightMotor.getBusVoltage());
   }


### PR DESCRIPTION
Previously when disabling and then restarting autonomous, the robot would keep its simulated position and then attempt to match up to the path planner from that position. Now, it "teleports" to the new position on reset so that the simulation does not need to be restarted between tests.